### PR TITLE
Caching configuration - Guava Cache Implementation

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -92,6 +92,11 @@
             <artifactId>spring-boot-autoconfigure</artifactId>
             <version>1.4.0.RELEASE</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context-support</artifactId>
+            <version>4.3.2.RELEASE</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/common/src/main/java/tds/common/configuration/CacheConfiguration.java
+++ b/common/src/main/java/tds/common/configuration/CacheConfiguration.java
@@ -2,6 +2,7 @@ package tds.common.configuration;
 
 import com.google.common.cache.CacheBuilder;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
@@ -9,6 +10,7 @@ import org.springframework.cache.guava.GuavaCache;
 import org.springframework.cache.guava.GuavaCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 
 import java.util.concurrent.TimeUnit;
 
@@ -17,7 +19,18 @@ import java.util.concurrent.TimeUnit;
  */
 @Configuration
 @EnableCaching
+@PropertySource("classpath:cache.properties")
 public class CacheConfiguration {
+
+    @Value("${tds.cache.expire.time.short:20}")
+    private Integer shortTermExpirationInSeconds;
+
+    @Value("${tds.cache.expire.time.medium:600}")
+    private Integer mediumTermExpirationInSeconds;
+
+    @Value("${tds.cache.expire.time.long:7200}")
+    private Integer longTermExpirationInSeconds;
+
     @Bean
     public CacheManager cacheManager() {
         return new GuavaCacheManager(CacheType.SHORT_TERM, CacheType.MEDIUM_TERM, CacheType.LONG_TERM);
@@ -27,7 +40,7 @@ public class CacheConfiguration {
     @Qualifier(CacheType.SHORT_TERM)
     public Cache shortTermCache() {
         return new GuavaCache(CacheType.SHORT_TERM, CacheBuilder.newBuilder()
-            .expireAfterWrite(20, TimeUnit.SECONDS)
+            .expireAfterWrite(shortTermExpirationInSeconds, TimeUnit.SECONDS)
             .build());
     }
 
@@ -35,7 +48,7 @@ public class CacheConfiguration {
     @Qualifier(CacheType.MEDIUM_TERM)
     public Cache mediumTermCache() {
         return new GuavaCache(CacheType.MEDIUM_TERM, CacheBuilder.newBuilder()
-            .expireAfterWrite(600, TimeUnit.SECONDS)
+            .expireAfterWrite(mediumTermExpirationInSeconds, TimeUnit.SECONDS)
             .build());
     }
 
@@ -43,7 +56,7 @@ public class CacheConfiguration {
     @Qualifier(CacheType.LONG_TERM)
     public Cache longTermCache() {
         return new GuavaCache(CacheType.LONG_TERM, CacheBuilder.newBuilder()
-            .expireAfterWrite(7200, TimeUnit.SECONDS)
+            .expireAfterWrite(longTermExpirationInSeconds, TimeUnit.SECONDS)
             .build());
     }
 }

--- a/common/src/main/java/tds/common/configuration/CacheConfiguration.java
+++ b/common/src/main/java/tds/common/configuration/CacheConfiguration.java
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit;
  */
 @Configuration
 @EnableCaching
-@PropertySource("classpath:cache.properties")
+@PropertySource(value="classpath:cache.properties", ignoreResourceNotFound=true)
 public class CacheConfiguration {
 
     @Value("${tds.cache.expire.time.short:20}")

--- a/common/src/main/java/tds/common/configuration/CacheConfiguration.java
+++ b/common/src/main/java/tds/common/configuration/CacheConfiguration.java
@@ -1,0 +1,49 @@
+package tds.common.configuration;
+
+import com.google.common.cache.CacheBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.guava.GuavaCache;
+import org.springframework.cache.guava.GuavaCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Spring Configuration file for caching
+ */
+@Configuration
+@EnableCaching
+public class CacheConfiguration {
+    @Bean
+    public CacheManager cacheManager() {
+        return new GuavaCacheManager(CacheType.SHORT_TERM, CacheType.MEDIUM_TERM, CacheType.LONG_TERM);
+    }
+
+    @Bean
+    @Qualifier(CacheType.SHORT_TERM)
+    public Cache shortTermCache() {
+        return new GuavaCache(CacheType.SHORT_TERM, CacheBuilder.newBuilder()
+            .expireAfterWrite(20, TimeUnit.SECONDS)
+            .build());
+    }
+
+    @Bean
+    @Qualifier(CacheType.MEDIUM_TERM)
+    public Cache mediumTermCache() {
+        return new GuavaCache(CacheType.MEDIUM_TERM, CacheBuilder.newBuilder()
+            .expireAfterWrite(600, TimeUnit.SECONDS)
+            .build());
+    }
+
+    @Bean
+    @Qualifier(CacheType.LONG_TERM)
+    public Cache longTermCache() {
+        return new GuavaCache(CacheType.LONG_TERM, CacheBuilder.newBuilder()
+            .expireAfterWrite(7200, TimeUnit.SECONDS)
+            .build());
+    }
+}

--- a/common/src/main/java/tds/common/configuration/CacheType.java
+++ b/common/src/main/java/tds/common/configuration/CacheType.java
@@ -1,0 +1,10 @@
+package tds.common.configuration;
+
+/**
+ * A class containing cache ids for various cache types
+ */
+public interface CacheType {
+    String SHORT_TERM = "shortTerm";
+    String MEDIUM_TERM = "mediumTerm";
+    String LONG_TERM = "longTerm";
+}

--- a/common/src/main/resources/cache.properties
+++ b/common/src/main/resources/cache.properties
@@ -1,0 +1,3 @@
+tds.cache.expire.time.short=40
+tds.cache.expire.time.medium=600
+tds.cache.expire.time.long=7200

--- a/common/src/main/resources/cache.properties
+++ b/common/src/main/resources/cache.properties
@@ -1,3 +1,0 @@
-tds.cache.expire.time.short=40
-tds.cache.expire.time.medium=600
-tds.cache.expire.time.long=7200


### PR DESCRIPTION
This pull request defines a common cache configuration using a Guava cache implementation

Support services will pull in this configuration and will be able to leverage the @Cacheable annotation along with one of the three cache types.

- Created a cache.properties file in src/resources to hold cache-specific properties
- Defined 3 caching lengths (short, medium, long term)

Default expiration times were ported over from the legacy Student application but we can redefine them at any point as we see fit. This PR does not contain any test coverage, but unit test coverage for caching can (and will) be included in individual support services. 