### PR TITLE
Re-release of 0.0.1 after groupId naming change

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>tds-common-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.1</version>
     </parent>
 
     <properties>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>tds-common-parent</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -7,9 +7,9 @@
     <packaging>jar</packaging>
 
     <parent>
-        <groupId>org.opentestsystem.common</groupId>
+        <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>tds-common-parent</artifactId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tds-common</artifactId>
     <name>tds-common</name>
@@ -11,7 +9,7 @@
     <parent>
         <groupId>org.opentestsystem.common</groupId>
         <artifactId>tds-common-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>tds-common-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.1</version>
     </parent>
 
     <properties>

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tds-common-legacy</artifactId>
     <name>tds-common-legacy</name>
@@ -11,7 +9,7 @@
     <parent>
         <groupId>org.opentestsystem.common</groupId>
         <artifactId>tds-common-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>tds-common-parent</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -7,9 +7,9 @@
     <packaging>jar</packaging>
 
     <parent>
-        <groupId>org.opentestsystem.common</groupId>
+        <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>tds-common-parent</artifactId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
     <artifactId>tds-common-parent</artifactId>
     <name>tds-common-parent</name>
     <packaging>pom</packaging>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.1</version>
 
     <scm>
         <connection>scm:git:https://github.com/SmarterApp/TDS_Common.git</connection>
         <developerConnection>scm:git:https://git@github.com/SmarterApp/TDS_Common.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_Common</url>
-        <tag>HEAD</tag>
+        <tag>0.0.1</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <artifactId>tds-common-parent</artifactId>
     <name>tds-common-parent</name>
     <packaging>pom</packaging>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
 
     <scm>
         <connection>scm:git:https://github.com/SmarterApp/TDS_Common.git</connection>
-        <developerConnection>scm:git:git@github.com:SmarterApp/TDS_Common.git</developerConnection>
+        <developerConnection>scm:git:https://git@github.com/SmarterApp/TDS_Common.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_Common</url>
         <tag>HEAD</tag>
     </scm>
@@ -24,11 +24,13 @@
         <unit-tests.skip>false</unit-tests.skip>
         <integration-tests.skip>true</integration-tests.skip>
         <assertj.version>3.4.1</assertj.version>
+
         <maven.compiler.plugin.version>3.5.1</maven.compiler.plugin.version>
         <maven.jar.plugin.version>2.3.2</maven.jar.plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <maven.source.plugin.version>2.1.2</maven.source.plugin.version>
         <maven.toolchains.plugin.version>1.1</maven.toolchains.plugin.version>
+
         <publish.package.name>tds.common</publish.package.name>
     </properties>
 
@@ -79,7 +81,7 @@
         <repository>
             <id>bintray-smarter-app-open-test-system</id>
             <name>smarter-app-open-test-system</name>
-            <url>https://api.bintray.com/maven/smarter-app/open-test-system/${publish.package.name}/</url>
+            <url>https://api.bintray.com/maven/smarter-app/open-test-system/${publish.package.name}/;publish=1</url>
         </repository>
     </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.opentestsystem.common</groupId>
+    <groupId>org.opentestsystem.delivery</groupId>
     <artifactId>tds-common-parent</artifactId>
     <name>tds-common-parent</name>
     <packaging>pom</packaging>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
 
     <scm>
         <connection>scm:git:https://github.com/SmarterApp/TDS_Common.git</connection>
@@ -31,7 +31,7 @@
         <maven.source.plugin.version>2.1.2</maven.source.plugin.version>
         <maven.toolchains.plugin.version>1.1</maven.toolchains.plugin.version>
 
-        <publish.package.name>tds.common</publish.package.name>
+        <publish.package.name>org.opentestsystem.tds.common</publish.package.name>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
     <artifactId>tds-common-parent</artifactId>
     <name>tds-common-parent</name>
     <packaging>pom</packaging>
-    <version>0.0.1</version>
+    <version>0.0.2-SNAPSHOT</version>
 
     <scm>
         <connection>scm:git:https://github.com/SmarterApp/TDS_Common.git</connection>
         <developerConnection>scm:git:https://git@github.com/SmarterApp/TDS_Common.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_Common</url>
-        <tag>0.0.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>


### PR DESCRIPTION
The SBAC teams have decided on a consistent naming convention for maven artifacts.  This required a re-release of 0.0.1 under the new groupId: org.opentestsystem.delivery
