### PR TITLE
RestTemplate request/response logging

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <spring.version>4.3.2.RELEASE</spring.version>
-        <spring.boot.version>1.4.0.RELEASE</spring.boot.version>
+        <spring.boot.version>1.4.2.RELEASE</spring.boot.version>
         <joda-time.version>2.9.5</joda-time.version>
         <jackson.modules.version>2.8.5</jackson.modules.version>
     </properties>

--- a/common/src/main/java/tds/common/configuration/RestTemplateConfiguration.java
+++ b/common/src/main/java/tds/common/configuration/RestTemplateConfiguration.java
@@ -1,7 +1,8 @@
 package tds.common.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -9,21 +10,18 @@ import org.springframework.http.client.BufferingClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.Arrays;
-
 import tds.common.web.interceptors.RestTemplateLoggingInterceptor;
 
 @Configuration
 @Import(JacksonObjectMapperConfiguration.class)
 public class RestTemplateConfiguration {
 
-    @Autowired
-    private ObjectMapper objectMapper;
-
     @Bean
-    public RestTemplate restTemplate() {
-        RestTemplate restTemplate = new RestTemplate(new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()));
-        restTemplate.setInterceptors(Arrays.asList(new RestTemplateLoggingInterceptor(objectMapper)));
-        return restTemplate;
+    @ConditionalOnMissingBean(RestTemplate.class)
+    public RestTemplate restTemplate(final RestTemplateBuilder builder, final ObjectMapper objectMapper) {
+        return builder
+            .requestFactory(new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()))
+            .additionalInterceptors(new RestTemplateLoggingInterceptor(objectMapper))
+            .build();
     }
 }

--- a/common/src/main/java/tds/common/configuration/RestTemplateConfiguration.java
+++ b/common/src/main/java/tds/common/configuration/RestTemplateConfiguration.java
@@ -1,14 +1,29 @@
 package tds.common.configuration;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.Arrays;
+
+import tds.common.web.interceptors.RestTemplateLoggingInterceptor;
+
 @Configuration
+@Import(JacksonObjectMapperConfiguration.class)
 public class RestTemplateConfiguration {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @Bean
-    public RestTemplate restTemplate(RestTemplateBuilder builder) {
-        return builder.build();
+    public RestTemplate restTemplate() {
+        RestTemplate restTemplate = new RestTemplate(new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()));
+        restTemplate.setInterceptors(Arrays.asList(new RestTemplateLoggingInterceptor(objectMapper)));
+        return restTemplate;
     }
 }

--- a/common/src/main/java/tds/common/web/interceptors/RestTemplateLoggingInterceptor.java
+++ b/common/src/main/java/tds/common/web/interceptors/RestTemplateLoggingInterceptor.java
@@ -1,0 +1,88 @@
+package tds.common.web.interceptors;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * An interceptor for logging REST requests and responses
+ */
+public class RestTemplateLoggingInterceptor implements ClientHttpRequestInterceptor {
+    private static final Logger log = LoggerFactory.getLogger(RestTemplateLoggingInterceptor.class);
+    private static final String CONTENT_TYPE_SUBTYPE_JSON = "json";
+    private ObjectMapper objectMapper;
+
+    public RestTemplateLoggingInterceptor(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public ClientHttpResponse intercept(final HttpRequest request, final byte[] body, final ClientHttpRequestExecution clientHttpRequestExecution) throws IOException {
+        logRequest(request, body);
+        ClientHttpResponse response = clientHttpRequestExecution.execute(request, body);
+        logResponse(response);
+        return response;
+    }
+
+    private void logRequest(final HttpRequest request, final byte[] body) {
+        final HttpHeaders headers = request.getHeaders();
+        String bodyString = new String(body, Charsets.UTF_8);
+
+        if (!bodyString.isEmpty() && headers.getAccept().contains(MediaType.APPLICATION_JSON)) {
+            try {
+                final Object json = objectMapper.readValue(bodyString, Object.class);
+                bodyString = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(json);
+            } catch (IOException e) {
+                log.debug("Unable to parse the request as JSON. Printing raw request body string...");
+            }
+        }
+
+        log.debug("=========================================* REQUEST *==========================================");
+        log.debug(" Method/URI  :   {} - {}", request.getMethod(), request.getURI());
+        log.debug(" Headers     :   {} ", request.getHeaders());
+        log.debug(" Body        :   {} ", bodyString);
+        log.debug("==============================================================================================");
+    }
+
+    private void logResponse(final ClientHttpResponse response) throws IOException {
+        StringBuilder inputStringBuilder = new StringBuilder();
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response.getBody(), Charsets.UTF_8));
+        String line = bufferedReader.readLine();
+
+        while (line != null) {
+            inputStringBuilder.append(line);
+            inputStringBuilder.append('\n');
+            line = bufferedReader.readLine();
+        }
+
+        String bodyString = inputStringBuilder.toString();
+        MediaType contentType = response.getHeaders().getContentType();
+
+        if (!bodyString.isEmpty() && contentType.getSubtype().equals(CONTENT_TYPE_SUBTYPE_JSON)) {
+            try {
+                final Object json = objectMapper.readValue(bodyString, Object.class);
+                bodyString = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(json);
+            } catch (IOException e) {
+                log.debug("Unable to parse the response as JSON. Printing raw response body string...");
+            }
+        }
+
+        log.debug("=========================================* RESPONSE *=========================================");
+        log.debug(" Status Code :   {}", response.getStatusCode());
+        log.debug(" Status Text :   {}", response.getStatusText());
+        log.debug(" Headers     :   {}", response.getHeaders());
+        log.debug(" Body        :   {}", bodyString);
+        log.debug("==============================================================================================");
+    }
+}

--- a/common/src/main/java/tds/common/web/interceptors/RestTemplateLoggingInterceptor.java
+++ b/common/src/main/java/tds/common/web/interceptors/RestTemplateLoggingInterceptor.java
@@ -2,6 +2,7 @@ package tds.common.web.interceptors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
+import com.google.common.io.CharStreams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
@@ -11,9 +12,10 @@ import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 
-import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.UUID;
 
 /**
  * An interceptor for logging REST requests and responses
@@ -21,25 +23,28 @@ import java.io.InputStreamReader;
 public class RestTemplateLoggingInterceptor implements ClientHttpRequestInterceptor {
     private static final Logger log = LoggerFactory.getLogger(RestTemplateLoggingInterceptor.class);
     private static final String CONTENT_TYPE_SUBTYPE_JSON = "json";
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
-    public RestTemplateLoggingInterceptor(ObjectMapper objectMapper) {
+    public RestTemplateLoggingInterceptor(final ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     @Override
     public ClientHttpResponse intercept(final HttpRequest request, final byte[] body, final ClientHttpRequestExecution clientHttpRequestExecution) throws IOException {
-        logRequest(request, body);
+        final UUID traceId = UUID.randomUUID();
+        logRequest(request, body, traceId);
         ClientHttpResponse response = clientHttpRequestExecution.execute(request, body);
-        logResponse(response);
+        logResponse(response, traceId);
         return response;
     }
 
-    private void logRequest(final HttpRequest request, final byte[] body) {
+    private void logRequest(final HttpRequest request, final byte[] body, final UUID traceId) {
         final HttpHeaders headers = request.getHeaders();
         String bodyString = new String(body, Charsets.UTF_8);
 
-        if (!bodyString.isEmpty() && headers.getAccept().contains(MediaType.APPLICATION_JSON)) {
+        MediaType contentType = request.getHeaders().getContentType();
+
+        if (!bodyString.isEmpty() && contentType.getSubtype().equals(CONTENT_TYPE_SUBTYPE_JSON)) {
             try {
                 final Object json = objectMapper.readValue(bodyString, Object.class);
                 bodyString = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(json);
@@ -49,24 +54,20 @@ public class RestTemplateLoggingInterceptor implements ClientHttpRequestIntercep
         }
 
         log.debug("=========================================* REQUEST *==========================================");
+        log.debug(" Trace ID    :   {}", traceId);
         log.debug(" Method/URI  :   {} - {}", request.getMethod(), request.getURI());
         log.debug(" Headers     :   {} ", request.getHeaders());
         log.debug(" Body        :   {} ", bodyString);
         log.debug("==============================================================================================");
     }
 
-    private void logResponse(final ClientHttpResponse response) throws IOException {
-        StringBuilder inputStringBuilder = new StringBuilder();
-        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response.getBody(), Charsets.UTF_8));
-        String line = bufferedReader.readLine();
+    private void logResponse(final ClientHttpResponse response, final UUID traceId) throws IOException {
+        String bodyString;
 
-        while (line != null) {
-            inputStringBuilder.append(line);
-            inputStringBuilder.append('\n');
-            line = bufferedReader.readLine();
+        try (final InputStream in = response.getBody()) {
+            bodyString = CharStreams.toString(new InputStreamReader(in, Charsets.UTF_8));
         }
 
-        String bodyString = inputStringBuilder.toString();
         MediaType contentType = response.getHeaders().getContentType();
 
         if (!bodyString.isEmpty() && contentType.getSubtype().equals(CONTENT_TYPE_SUBTYPE_JSON)) {
@@ -79,6 +80,7 @@ public class RestTemplateLoggingInterceptor implements ClientHttpRequestIntercep
         }
 
         log.debug("=========================================* RESPONSE *=========================================");
+        log.debug(" Trace ID    :   {}", traceId);
         log.debug(" Status Code :   {}", response.getStatusCode());
         log.debug(" Status Text :   {}", response.getStatusText());
         log.debug(" Headers     :   {}", response.getHeaders());


### PR DESCRIPTION
RestTemplateLoggingInterceptor for logging RestTemplate requests/responses and other data.

- Leverages slf4j for logging
- If a JSON response/request is detected, the interceptor will attempt to format the JSON in a more human-readable format (pretty-print).

A Java 7 compliant port of this code will be added to SS_SharedMultiJar repo, under a new "shared-spring" submodule, which will be used by TDS_Student and TDS_Proctor.