### PR TITLE
Feature/shared logback config

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -16,6 +16,8 @@
         <java.version>1.8</java.version>
         <joda-time.version>2.9.5</joda-time.version>
         <jackson.modules.version>2.8.5</jackson.modules.version>
+        <janino.version>3.0.7</janino.version>
+        <logstash-appender.version>4.8</logstash-appender.version>
     </properties>
 
 <!--
@@ -27,7 +29,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>Camden.SR6</version>
+                <version>Dalston.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -136,13 +138,14 @@
 
         <!-- Logging dependencies -->
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-logging</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.codehaus.janino</groupId>
             <artifactId>janino</artifactId>
-            <version>2.6.1</version>
+            <version>${janino.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>${logstash-appender.version}</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -136,9 +136,13 @@
 
         <!-- Logging dependencies -->
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.21</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.janino</groupId>
+            <artifactId>janino</artifactId>
+            <version>2.6.1</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/common/src/main/resources/tds/common/logging/logstash.xml
+++ b/common/src/main/resources/tds/common/logging/logstash.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Root logger is set to INFO and logs are sent to CONSOLE and logstash via tcp.
+
+Spring boot default log levels are used.
+-->
+<included>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <springProperty name="LOGSTASH_DESTINATION" source="logstash-destination"/>
+
+    <if condition='isDefined("LOGSTASH_DESTINATION")'>
+        <then>
+            <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+                <destination>${LOGSTASH_DESTINATION}</destination>
+                <!-- encoder is required -->
+                <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+            </appender>
+        </then>
+    </if>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+
+        <if condition='isDefined("LOGSTASH_DESTINATION")'>
+            <then>
+                <appender-ref ref="LOGSTASH"/>
+            </then>
+        </if>
+    </root>
+</included>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.4.2.RELEASE</version>
+        <version>1.5.2.RELEASE</version>
     </parent>
 
     <scm>


### PR DESCRIPTION
Define a single logback configuration file for all micro-services to reference.

Upgrading to spring boot 1.5.2 and spring cloud Dalston.RELEASE.

Log level set to INFO and sent to CONSOLE and logstash server via logback appender.