### PR TITLE
Feature/tracer

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -117,6 +117,10 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-bus-amqp</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-sleuth</artifactId>
+        </dependency>
 
         <!-- Jackson dependencies -->
         <dependency>

--- a/common/src/main/java/tds/common/configuration/EventLoggerConfiguration.java
+++ b/common/src/main/java/tds/common/configuration/EventLoggerConfiguration.java
@@ -1,9 +1,36 @@
 package tds.common.configuration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.handler.MappedInterceptor;
+
+import tds.common.web.interceptors.EventLoggerInterceptor;
 
 @Configuration
 @ComponentScan(basePackages = "tds.common.logging")
 public class EventLoggerConfiguration {
+  private final ApplicationContext applicationContext;
+  private final ObjectMapper objectMapper;
+
+  @Autowired
+  public EventLoggerConfiguration(final ApplicationContext applicationContext,
+                                  final ObjectMapper objectMapper) {
+    this.applicationContext = applicationContext;
+    this.objectMapper = objectMapper;
+  }
+
+  /**
+   * Log incoming http requests formatted for logstash centralized logging
+   *
+   * @return http interceptor that delegates calls to {@link EventLoggerInterceptor}
+   */
+  @Bean
+  public MappedInterceptor eventInterceptor()
+  {
+    return new MappedInterceptor(null, new EventLoggerInterceptor(applicationContext.getId(), objectMapper));
+  }
 }


### PR DESCRIPTION
Enable spring cloud sleuth for log entries.
This allows requests to be tracked through nested calls to other micro-services.
The nested tree of calls share a common trace id that is generated at the first entry point.

In addition, enabling the logging of incoming http requests of microservices is being moved to this single, common codebase.