### PR TITLE
Move event logs from info to trace

### DIFF
--- a/common/src/main/java/tds/common/logging/ApplicationShutdownLogger.java
+++ b/common/src/main/java/tds/common/logging/ApplicationShutdownLogger.java
@@ -31,7 +31,7 @@ public class ApplicationShutdownLogger implements ApplicationListener<ContextClo
     public void onApplicationEvent(final ContextClosedEvent event) {
         if (!logged) {
             logged = true;
-            logger.info(appId, APP_SHUTDOWN.name(), null, null, null);
+            logger.trace(appId, APP_SHUTDOWN.name(), null, null, null);
         }
     }
 }

--- a/common/src/main/java/tds/common/logging/ApplicationStartupLogger.java
+++ b/common/src/main/java/tds/common/logging/ApplicationStartupLogger.java
@@ -31,7 +31,7 @@ public class ApplicationStartupLogger implements ApplicationListener<ContextRefr
     public void onApplicationEvent(final ContextRefreshedEvent event) {
         if (!logged) {
             logged = true;
-            logger.info(appId, APP_STARTUP.name(), null, null, null);
+            logger.trace(appId, APP_STARTUP.name(), null, null, null);
         }
     }
 }

--- a/common/src/main/java/tds/common/logging/EventLogger.java
+++ b/common/src/main/java/tds/common/logging/EventLogger.java
@@ -64,14 +64,14 @@ public class EventLogger {
     }
 
     /**
-     * Add a supplemental piece of info that will be logged on subsequent log calls.
+     * Add a supplemental piece of trace that will be logged on subsequent log calls.
      */
     public void putField(final String key, final Object value) {
         extraFields.put(key, value);
     }
 
     /**
-     * Get a supplemental piece of info that was placed into the logger.
+     * Get a supplemental piece of trace that was placed into the logger.
      */
     public Object getField(final String key) {
         return extraFields.get(key);
@@ -88,8 +88,8 @@ public class EventLogger {
      * @param message    an optional free-format message string to add to the log entry
      * @param data       optional searchable event data to add to the recorded event
      */
-    public void info(final String app, final String logEvent, final String checkpoint,
-                     final String message, final Map<EventData, Object> data) {
+    public void trace(final String app, final String logEvent, final String checkpoint,
+                      final String message, final Map<EventData, Object> data) {
         log(formatMessage(logEvent, message), getFieldMap(app, checkpoint, data));
     }
 
@@ -119,7 +119,7 @@ public class EventLogger {
 
     private void log(final String event, final Map<String, Object> fields) {
         try {
-            logger.info(marker, format("EVENT:%s JSON:({\"event_data\": %s})", event, writer.writeValueAsString(fields)));
+            logger.trace(marker, format("EVENT:%s JSON:({\"event_data\": %s})", event, writer.writeValueAsString(fields)));
         } catch (Exception e) {
             logger.warn(marker, format("exception occurred while logging event: %s", event), e);
         }

--- a/common/src/main/java/tds/common/logging/EventLogger.java
+++ b/common/src/main/java/tds/common/logging/EventLogger.java
@@ -64,14 +64,14 @@ public class EventLogger {
     }
 
     /**
-     * Add a supplemental piece of trace that will be logged on subsequent log calls.
+     * Add a supplemental piece of info that will be logged on subsequent log calls.
      */
     public void putField(final String key, final Object value) {
         extraFields.put(key, value);
     }
 
     /**
-     * Get a supplemental piece of trace that was placed into the logger.
+     * Get a supplemental piece of info that was placed into the logger.
      */
     public Object getField(final String key) {
         return extraFields.get(key);

--- a/common/src/main/java/tds/common/web/interceptors/EventLoggerInterceptor.java
+++ b/common/src/main/java/tds/common/web/interceptors/EventLoggerInterceptor.java
@@ -48,7 +48,7 @@ public class EventLoggerInterceptor extends HandlerInterceptorAdapter {
         }
         eventLogger.putField(HTTP_REQUEST_PARAMETERS.name(), request.getParameterMap());
         eventLogger.setBeginMillis(System.currentTimeMillis());
-        eventLogger.info(app, request.getRequestURI(), ENTER.name(), null, null);
+        eventLogger.trace(app, request.getRequestURI(), ENTER.name(), null, null);
         return true;
     }
 
@@ -61,6 +61,6 @@ public class EventLoggerInterceptor extends HandlerInterceptorAdapter {
         final EventLogger eventLogger = (EventLogger)request.getAttribute(EVENT_LOGGER_ATTRIBUTE);
         eventLogger.putField(RESPONSE_CODE.name(), response.getStatus());
         eventLogger.setEndMillis(System.currentTimeMillis());
-        eventLogger.info(app, request.getRequestURI(), EXIT.name(), null, null);
+        eventLogger.trace(app, request.getRequestURI(), EXIT.name(), null, null);
     }
 }

--- a/common/src/main/java/tds/common/web/interceptors/RestTemplateLoggingInterceptor.java
+++ b/common/src/main/java/tds/common/web/interceptors/RestTemplateLoggingInterceptor.java
@@ -79,7 +79,7 @@ public class RestTemplateLoggingInterceptor implements ClientHttpRequestIntercep
         eventLogger.putField(TRACE_ID.name(), traceId);
         eventLogger.putField(HTTP_HEADERS.name(), request.getHeaders());
         eventLogger.setBeginMillis(System.currentTimeMillis());
-        eventLogger.info(appId, request.getURI().getPath(), SERVICE_CALL.name(), null, null);
+        eventLogger.trace(appId, request.getURI().getPath(), SERVICE_CALL.name(), null, null);
     }
 
     private void logResponse(final HttpRequest request, final ClientHttpResponse response, final UUID traceId, final EventLogger eventLogger) throws IOException {
@@ -122,6 +122,6 @@ public class RestTemplateLoggingInterceptor implements ClientHttpRequestIntercep
         } catch (Exception ignored) {
         }
         eventLogger.setEndMillis(System.currentTimeMillis());
-        eventLogger.info(appId, request.getURI().getPath(), SERVICE_RETURN.name(), null, null);
+        eventLogger.trace(appId, request.getURI().getPath(), SERVICE_RETURN.name(), null, null);
     }
 }

--- a/common/src/main/resources/tds/common/logging/logstash.xml
+++ b/common/src/main/resources/tds/common/logging/logstash.xml
@@ -22,6 +22,11 @@ Spring boot default log levels are used.
                 <!-- encoder is required -->
                 <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
             </appender>
+
+            <!-- send trace event logs to LOGSTASH but not to CONSOLE-->
+            <logger name="tds.common.logging.EventLogger" level="trace" additive="false">
+                <appender-ref ref="LOGSTASH"/>
+            </logger>
         </then>
     </if>
 


### PR DESCRIPTION
Send event trace logs to logstash, but not the console by default.

Move event logs from info level to trace.  Sending EventLogger trace entries to logstash.
Console logs remain at info level.