### PR TITLE
Exclude exam service heath checks

### DIFF
--- a/common/src/main/java/tds/common/configuration/EventLoggerConfiguration.java
+++ b/common/src/main/java/tds/common/configuration/EventLoggerConfiguration.java
@@ -16,7 +16,7 @@ public class EventLoggerConfiguration {
   private final ApplicationContext applicationContext;
   private final ObjectMapper objectMapper;
   private static final String INCLUDE_ALL_PATTERN = "/**";
-  private static final String EXCLUDE_HEALTH_PATTERN = "/health*";
+  private static final String EXCLUDE_HEALTH_PATTERN = "/**/health*";
 
   @Autowired
   public EventLoggerConfiguration(final ApplicationContext applicationContext,


### PR DESCRIPTION
Exam service has an additional path element in the health url.
Changing the path exclusion pattern to test positive in that case.